### PR TITLE
Forbidden characters in directory

### DIFF
--- a/animeX.py
+++ b/animeX.py
@@ -63,7 +63,7 @@ def download_episode(anime_name, download_url):
     new_anime_name = ""
     for char in anime_name:
         if char.isalnum() or char == " ":
-            new_anime_name += char
+            new_anime_name += char # ensures no forbidden characters like * . " / \ [ ] : ; | ,
     filename = os.path.basename(download_url)
     download_path = os.path.join(new_anime_name, filename)
     if not os.path.exists(download_path):
@@ -78,7 +78,7 @@ def make_directory(anime_name):
     if not os.path.exists(anime_name):
         for char in anime_name:
             if char.isalnum() or char == " ":
-                new_anime_name += char
+                new_anime_name += char  # ensures no forbidden characters like * . " / \ [ ] : ; | ,
         os.mkdir(new_anime_name)
 
 

--- a/animeX.py
+++ b/animeX.py
@@ -60,18 +60,26 @@ def get_download_url(anime_url):
 def download_episode(anime_name, download_url):
     # download anime and store in the folder the same name
     # don't download files that exist and clear tmp files after download
+    new_anime_name = ""
+    for char in anime_name:
+        if char.isalnum() or char == " ":
+            new_anime_name += char
     filename = os.path.basename(download_url)
-    download_path = os.path.join(anime_name, filename)
+    download_path = os.path.join(new_anime_name, filename)
     if not os.path.exists(download_path):
         print("\nDownloading", filename)
-        #wget.download(download_url, download_path)
-        clear_tmp(anime_name)
+        # wget.download(download_url, download_path)
+        clear_tmp(new_anime_name)
 
 
 def make_directory(anime_name):
     # create folder to store anime
+    new_anime_name = ""
     if not os.path.exists(anime_name):
-        os.mkdir(anime_name)
+        for char in anime_name:
+            if char.isalnum() or char == " ":
+                new_anime_name += char
+        os.mkdir(new_anime_name)
 
 
 def clear_tmp(directory):


### PR DESCRIPTION
Characters such as `* . " / \ [ ] : ; | ,` are forbidden in directory names. Whenever such appears in anime name, the script fails to create such directory.

This PR fixes such issues by performing the following:

-  RegEx seems to be an overkill
- Check for alphanumeric characters and space in anime name and returns exactly that, leaving symbols and forbidden characters out
- Creates the directory in the above format.